### PR TITLE
Fix mysql connection settings

### DIFF
--- a/bootstrap-mods/mistral.sh
+++ b/bootstrap-mods/mistral.sh
@@ -74,7 +74,7 @@ cat <<mistral_config >$config
 connection=mysql://mistral:StackStorm@localhost/mistral
 max_pool_size=100
 max_overflow=400
-pool_recycle=3600
+pool_recycle=120
 
 [pecan]
 auth_enable=false
@@ -125,6 +125,10 @@ mysql -uroot -pStackStorm -e "FLUSH PRIVILEGES"
 
 cd ${OPT_DIR}/mistral
 ${OPT_DIR}/mistral/.venv/bin/python ./tools/sync_db.py --config-file ${CONFIG_DIR}/mistral.conf
+
+sed -i 's/#max_connections        = 100/max_connections        = 500/' /etc/mysql/my.cnf
+service mysql restart
+
 mistral_reset_db
 chmod +x $reset_db
 }


### PR DESCRIPTION
Reduce the pool recycle time to 120 seconds. During load testing, mistral was not reusing connections in the pool if recycle time is set too high. Change the mysql max_connections to 500 so it is consistent with the SQLAlchemy settings for mistral.